### PR TITLE
Missing parent directory to create template

### DIFF
--- a/recipes/install_linux.rb
+++ b/recipes/install_linux.rb
@@ -6,7 +6,7 @@ remote_file zipfile do
   not_if { ::File.exist?("/opt/local/gauge/.version-#{node['gauge']['version']}") }
 end
 
-directory '/opt/local/gauge' do
+directory '/opt/local/gauge/share/gauge' do
   owner 'root'
   group 'root'
   mode  '0755'


### PR DESCRIPTION
         * template[/opt/local/gauge/share/gauge/gauge.properties] action create
           * Parent directory /opt/local/gauge/share/gauge does not exist.
           ================================================================================
           Error executing action `create` on resource 'template[/opt/local/gauge/share/gauge/gauge.properties]'
           ================================================================================
           
           Chef::Exceptions::EnclosingDirectoryDoesNotExist
           ------------------------------------------------
           Parent directory /opt/local/gauge/share/gauge does not exist.
           
           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/gauge/recipes/install_linux.rb
           
            49: template '/opt/local/gauge/share/gauge/gauge.properties' do
            50:   owner 'root'
            51:   group 'root'
            52:   mode  '0644'
            53: end
            54: